### PR TITLE
Updating integrate env with version fixes

### DIFF
--- a/workflow/envs/integrate.yaml
+++ b/workflow/envs/integrate.yaml
@@ -6,11 +6,12 @@ channels:
   - defaults
 dependencies:
   - python>=3.7,<=3.10
-  - numpy>=1.19.0
-  - pandas>=1.2.0
+  - matplotlib<3.7
+  - numpy>=1.19.0,<=1.23.5
+  - pandas>=1.2.0,<1.5.0
   - scipy>=1.5.0
   - leidenalg>=0.8.0
-  - umap-learn>=0.5.0
+  - umap-learn>=0.5.0,<=0.5.3
   - mnnpy>=0.1.9
   - scikit-learn>=1.0.1
   - scanpy=1.8.2
@@ -31,5 +32,6 @@ dependencies:
   - r-reticulate=1.24
   - cython>=0.29.25
   - r-rann=2.6.1
-variables:
-  TMPDIR: "TMPDIR=/scratch/gobi2/hmaan/Documents/Iniquitate/workflow/tmp"
+  - natsort>=7.0.0
+# variables:
+#   TMPDIR: -Add a tmpdir here, should be within workflow folder 


### PR DESCRIPTION
- This version of `integrate.yaml` pins the numpy and pandas versions to avoid conflicts and errors with latest version of other libraries that aren't pinned
- Also adds natsort which serves a number of branches 
- `tmpdir` is not pinned (it shouldn't be in the main branch, this should be customizable - to add)