### PR TITLE
Install fixes nov 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A separate README for the imbalanced integration guidelines, with full environme
 
 ### Reproducing the paper analysis 
 
-Please note that `mamba` and `snakemake` are required to run the pipeline through `conda`. After installing `conda` (https://conda.io/projects/conda/en/latest/user-guide/install/index.html), please add `mamba` (https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html) to the base environment, as well as `snakemake` (https://snakemake.readthedocs.io/en/stable/getting_started/installation.html) in base or a new environment:
+Please note that `mamba` and `snakemake` are required to run the pipeline through `conda`. After installing `conda` (https://conda.io/projects/conda/en/latest/user-guide/install/index.html), please add `mamba` (https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html) to the base environment, as well as `snakemake` (https://snakemake.readthedocs.io/en/stable/getting_started/installation.html) in base or a new environment. Please note that the snakemake version has to be restricted due to recent changes breaking the current setup (see code below):
 
 ```
 conda install -n base -c conda-forge mamba

--- a/workflow/envs/analysis.yaml
+++ b/workflow/envs/analysis.yaml
@@ -14,7 +14,7 @@ dependencies:
   - plotnine>=0.8.0
   - leidenalg>=0.8.0
   - umap-learn>=0.5.0
-  - scikit-learn>=1.0.1
+  - scikit-learn=1.0.1
   - scanpy=1.8.2
   - anndata>=0.7.5
   - ipykernel>=6.4.0

--- a/workflow/envs/analysis.yaml
+++ b/workflow/envs/analysis.yaml
@@ -52,3 +52,4 @@ dependencies:
   - r-networkd3>=0.4
   - r-emt>=1.2
   - cython>=0.29.25
+  - mkl==2024.0 # Pinning due to https://github.com/pytorch/pytorch/issues/123097

--- a/workflow/envs/integrate.yaml
+++ b/workflow/envs/integrate.yaml
@@ -21,7 +21,7 @@ dependencies:
   - torchmetrics<=0.6.0 # Issue with torch loading
   - cudatoolkit=10.2
   - scvi-tools=0.14.4
-  - bbknn=1.5.1
+  - bbknn=1.6.0
   - harmonypy=0.0.5
   - scanorama=1.7.1
   - r-base>=4.0.0

--- a/workflow/envs/integrate.yaml
+++ b/workflow/envs/integrate.yaml
@@ -13,7 +13,7 @@ dependencies:
   - leidenalg>=0.8.0
   - umap-learn>=0.5.0,<=0.5.3
   - mnnpy>=0.1.9.0,<=0.1.9.5
-  - scikit-learn>=1.0.1
+  - scikit-learn=1.0.1
   - scanpy=1.8.2
   - anndata=0.8.0
   - faiss-cpu>=1.7.0,<=1.7.3
@@ -21,7 +21,7 @@ dependencies:
   - torchmetrics<=0.6.0 # Issue with torch loading
   - cudatoolkit=10.2
   - scvi-tools=0.14.4
-  - bbknn=1.6.0
+  - bbknn=1.5.1
   - harmonypy=0.0.5
   - scanorama=1.7.1
   - r-base>=4.0.0

--- a/workflow/envs/integrate.yaml
+++ b/workflow/envs/integrate.yaml
@@ -35,6 +35,7 @@ dependencies:
   - natsort>=7.0.0
   - colorcet>=3.0.0
   - seaborn>=0.11.0
+  - mkl==2024.0 # Pinning due to https://github.com/pytorch/pytorch/issues/123097
 variables:
   TMPDIR: "/tmp" 
   


### PR DESCRIPTION
- Restricting sklearn version due to changes in `Neighbors` and `Metrics` classes (broke BBKNN)
- Adding dependency fix for torch (`mkl` version restriction) 
- Updating readme to reflect changes in snakemake version restriction